### PR TITLE
Fix button: change color, translucent background across screen

### DIFF
--- a/src/app/_pages/join/join.page.html
+++ b/src/app/_pages/join/join.page.html
@@ -10,4 +10,6 @@
     </mat-list-option>
 </mat-selection-list>
 
-<button mat-raised-button>Join Groups</button>
+<div class="join-groups-button">
+  <button mat-raised-button color="primary">Join Groups</button>
+</div>

--- a/src/app/_pages/join/join.page.scss
+++ b/src/app/_pages/join/join.page.scss
@@ -3,9 +3,18 @@ mat-grid-tile {
     border-radius: 5px;
 }
 
-button {
+.join-groups-button {
+    width: 100vw;
+    height: 70px;
     position: fixed; 
-    bottom: 30px;
+    bottom: 0px;
+    left: 0px;
+    background-color: rgba(75, 75, 75, 0.5);
+}
+
+button {
+    position: fixed;
+    bottom: 10px;
     right: 30px;
     border: 0px solid #d6d6d6;
     width: 150px;


### PR DESCRIPTION
Change the color of the 'join groups' button to the primary blue color. Add a translucent background that wraps the 'join groups' button to increase visibility when scrolling.

Button will always be at the bottom right of the screen:
<img width="1200" alt="Screen Shot 2020-03-24 at 1 20 33 PM" src="https://user-images.githubusercontent.com/26643784/77457005-71524c00-6dd2-11ea-9d87-e3ae75225523.png">

Demonstrating the translucent background when scrolling:
<img width="610" alt="Screen Shot 2020-03-24 at 1 15 40 PM" src="https://user-images.githubusercontent.com/26643784/77457045-7f07d180-6dd2-11ea-9148-366632dcb785.png">
